### PR TITLE
feat: make grouping constraints advisory only

### DIFF
--- a/src/grouping/validator.ts
+++ b/src/grouping/validator.ts
@@ -1,6 +1,7 @@
 /**
  * Grouping constraint validator
- * Enforces grouping constraints and validates tool groups using Zod
+ * Validates tool group metadata (IDs, names, descriptions) using Zod.
+ * Note: Tool count and group count constraints are advisory only and not enforced.
  */
 
 import { GroupingConstraintsRequiredSchema, ToolGroupSchema } from "../schemas/index.ts";
@@ -43,35 +44,8 @@ export function validateGroups(
     };
   }
 
-  // NOTE: Grouping constraints (tool count and group count) are now advisory only.
-  // They are not enforced during validation to allow flexibility in tool grouping.
-  // The constraints serve as guidelines for the LLM during the grouping process.
-
-  // COMMENTED OUT: Group count validation (advisory only)
-  // if (groups.length < validatedConstraints.minGroups) {
-  //   errors.push(
-  //     `Too few groups: ${groups.length} (minimum constraint: ${validatedConstraints.minGroups})`,
-  //   );
-  // }
-  // if (groups.length > validatedConstraints.maxGroups) {
-  //   errors.push(
-  //     `Too many groups: ${groups.length} (maximum constraint: ${validatedConstraints.maxGroups})`,
-  //   );
-  // }
-
-  // COMMENTED OUT: Tools per group validation (advisory only)
-  // groups.forEach((group) => {
-  //   if (group.tools.length < validatedConstraints.minToolsPerGroup) {
-  //     errors.push(
-  //       `Group "${group.name}" has too few tools: ${group.tools.length} (minimum constraint: ${validatedConstraints.minToolsPerGroup})`,
-  //     );
-  //   }
-  //   if (group.tools.length > validatedConstraints.maxToolsPerGroup) {
-  //     errors.push(
-  //       `Group "${group.name}" has too many tools: ${group.tools.length} (maximum constraint: ${validatedConstraints.maxToolsPerGroup})`,
-  //     );
-  //   }
-  // });
+  // NOTE: Tool count and group count constraints are advisory only.
+  // They serve as guidelines for the LLM during grouping but are not enforced here.
 
   // Validate unique group IDs
   const groupIds = groups.map((g) => g.id);

--- a/src/grouping/validator.ts
+++ b/src/grouping/validator.ts
@@ -43,34 +43,35 @@ export function validateGroups(
     };
   }
 
-  // Use validated constraints
-  const validatedConstraints = constraintsResult.data;
+  // NOTE: Grouping constraints (tool count and group count) are now advisory only.
+  // They are not enforced during validation to allow flexibility in tool grouping.
+  // The constraints serve as guidelines for the LLM during the grouping process.
 
-  // Validate group count against constraints
-  if (groups.length < validatedConstraints.minGroups) {
-    errors.push(
-      `Too few groups: ${groups.length} (minimum constraint: ${validatedConstraints.minGroups})`,
-    );
-  }
-  if (groups.length > validatedConstraints.maxGroups) {
-    errors.push(
-      `Too many groups: ${groups.length} (maximum constraint: ${validatedConstraints.maxGroups})`,
-    );
-  }
+  // COMMENTED OUT: Group count validation (advisory only)
+  // if (groups.length < validatedConstraints.minGroups) {
+  //   errors.push(
+  //     `Too few groups: ${groups.length} (minimum constraint: ${validatedConstraints.minGroups})`,
+  //   );
+  // }
+  // if (groups.length > validatedConstraints.maxGroups) {
+  //   errors.push(
+  //     `Too many groups: ${groups.length} (maximum constraint: ${validatedConstraints.maxGroups})`,
+  //   );
+  // }
 
-  // Validate tools per group against constraints
-  groups.forEach((group) => {
-    if (group.tools.length < validatedConstraints.minToolsPerGroup) {
-      errors.push(
-        `Group "${group.name}" has too few tools: ${group.tools.length} (minimum constraint: ${validatedConstraints.minToolsPerGroup})`,
-      );
-    }
-    if (group.tools.length > validatedConstraints.maxToolsPerGroup) {
-      errors.push(
-        `Group "${group.name}" has too many tools: ${group.tools.length} (maximum constraint: ${validatedConstraints.maxToolsPerGroup})`,
-      );
-    }
-  });
+  // COMMENTED OUT: Tools per group validation (advisory only)
+  // groups.forEach((group) => {
+  //   if (group.tools.length < validatedConstraints.minToolsPerGroup) {
+  //     errors.push(
+  //       `Group "${group.name}" has too few tools: ${group.tools.length} (minimum constraint: ${validatedConstraints.minToolsPerGroup})`,
+  //     );
+  //   }
+  //   if (group.tools.length > validatedConstraints.maxToolsPerGroup) {
+  //     errors.push(
+  //       `Group "${group.name}" has too many tools: ${group.tools.length} (maximum constraint: ${validatedConstraints.maxToolsPerGroup})`,
+  //     );
+  //   }
+  // });
 
   // Validate unique group IDs
   const groupIds = groups.map((g) => g.id);

--- a/tests/unit/grouping/validator_test.ts
+++ b/tests/unit/grouping/validator_test.ts
@@ -32,7 +32,7 @@ describe("Grouping Validator", () => {
       assertEquals(result.errors.length, 0, "Should have no errors");
     });
 
-    it("should fail validation when group count is below minimum", () => {
+    it("should pass validation when group count is below minimum (advisory only)", () => {
       // Arrange
       const groups = createMockGroups(2, 10);
       const constraints: GroupingConstraints = {
@@ -46,15 +46,20 @@ describe("Grouping Validator", () => {
       const result = validateGroups(groups, constraints);
 
       // Assert
-      assertEquals(result.valid, false, "Should fail validation for too few groups");
-      assert(result.errors.length > 0, "Should have errors");
-      assert(
-        result.errors.some((e) => e.includes("minimum") && e.includes("groups")),
-        "Error should mention minimum groups constraint",
+      // Constraints are advisory only, so validation should still pass
+      assertEquals(
+        result.valid,
+        true,
+        "Should pass validation even with fewer groups (advisory constraint)",
+      );
+      assertEquals(
+        result.errors.length,
+        0,
+        "Should have no errors for advisory constraint violation",
       );
     });
 
-    it("should fail validation when group count is above maximum", () => {
+    it("should pass validation when group count is above maximum (advisory only)", () => {
       // Arrange
       const groups = createMockGroups(12, 5);
       const constraints: GroupingConstraints = {
@@ -68,11 +73,16 @@ describe("Grouping Validator", () => {
       const result = validateGroups(groups, constraints);
 
       // Assert
-      assertEquals(result.valid, false, "Should fail validation for too many groups");
-      assert(result.errors.length > 0, "Should have errors");
-      assert(
-        result.errors.some((e) => e.includes("maximum") && e.includes("groups")),
-        "Error should mention maximum groups constraint",
+      // Constraints are advisory only, so validation should still pass
+      assertEquals(
+        result.valid,
+        true,
+        "Should pass validation even with more groups (advisory constraint)",
+      );
+      assertEquals(
+        result.errors.length,
+        0,
+        "Should have no errors for advisory constraint violation",
       );
     });
   });
@@ -95,7 +105,7 @@ describe("Grouping Validator", () => {
       assertEquals(result.valid, true, "Should pass validation for valid tool counts");
     });
 
-    it("should fail validation when a group has too few tools", () => {
+    it("should pass validation when a group has too few tools (advisory only)", () => {
       // Arrange
       const groups = createMockGroups(3, 10);
       groups[2].tools = groups[2].tools.slice(0, 3); // Reduce last group to 3 tools
@@ -110,14 +120,20 @@ describe("Grouping Validator", () => {
       const result = validateGroups(groups, constraints);
 
       // Assert
-      assertEquals(result.valid, false, "Should fail validation for group with too few tools");
-      assert(
-        result.errors.some((e) => e.includes("minimum") && e.includes("tools")),
-        "Error should mention minimum tools constraint",
+      // Constraints are advisory only, so validation should still pass
+      assertEquals(
+        result.valid,
+        true,
+        "Should pass validation even with group with too few tools (advisory constraint)",
+      );
+      assertEquals(
+        result.errors.length,
+        0,
+        "Should have no errors for advisory constraint violation",
       );
     });
 
-    it("should fail validation when a group has too many tools", () => {
+    it("should pass validation when a group has too many tools (advisory only)", () => {
       // Arrange
       const groups = createMockGroups(3, 10);
       // Add extra tools to first group
@@ -133,14 +149,20 @@ describe("Grouping Validator", () => {
       const result = validateGroups(groups, constraints);
 
       // Assert
-      assertEquals(result.valid, false, "Should fail validation for group with too many tools");
-      assert(
-        result.errors.some((e) => e.includes("maximum") && e.includes("tools")),
-        "Error should mention maximum tools constraint",
+      // Constraints are advisory only, so validation should still pass
+      assertEquals(
+        result.valid,
+        true,
+        "Should pass validation even with group with too many tools (advisory constraint)",
+      );
+      assertEquals(
+        result.errors.length,
+        0,
+        "Should have no errors for advisory constraint violation",
       );
     });
 
-    it("should report all groups that violate constraints", () => {
+    it("should pass validation even when multiple groups violate constraints (advisory only)", () => {
       // Arrange
       const groups = createMockGroups(5, 10);
       groups[1].tools = groups[1].tools.slice(0, 2); // Too few
@@ -156,8 +178,17 @@ describe("Grouping Validator", () => {
       const result = validateGroups(groups, constraints);
 
       // Assert
-      assertEquals(result.valid, false, "Should fail validation");
-      assert(result.errors.length >= 2, "Should report errors for both violating groups");
+      // Constraints are advisory only, so validation should still pass
+      assertEquals(
+        result.valid,
+        true,
+        "Should pass validation even with multiple constraint violations (advisory)",
+      );
+      assertEquals(
+        result.errors.length,
+        0,
+        "Should have no errors for advisory constraint violations",
+      );
     });
   });
 
@@ -373,7 +404,7 @@ describe("Grouping Validator", () => {
   });
 
   describe("Edge cases", () => {
-    it("should handle empty group list", () => {
+    it("should pass validation even for empty group list (advisory constraint)", () => {
       // Arrange
       const groups: ToolGroup[] = [];
       const constraints: GroupingConstraints = {
@@ -387,10 +418,16 @@ describe("Grouping Validator", () => {
       const result = validateGroups(groups, constraints);
 
       // Assert
-      assertEquals(result.valid, false, "Should fail validation for empty group list");
-      assert(
-        result.errors.some((e) => e.includes("minimum") && e.includes("groups")),
-        "Should report minimum groups violation",
+      // Constraints are advisory only, so validation should pass even for empty list
+      assertEquals(
+        result.valid,
+        true,
+        "Should pass validation even for empty group list (advisory constraint)",
+      );
+      assertEquals(
+        result.errors.length,
+        0,
+        "Should have no errors for advisory constraint violation",
       );
     });
 
@@ -411,10 +448,10 @@ describe("Grouping Validator", () => {
       assertEquals(result.valid, true, "Should pass validation for single group if allowed");
     });
 
-    it("should accumulate all validation errors", () => {
+    it("should accumulate metadata validation errors only (constraints are advisory)", () => {
       // Arrange
-      const groups = createMockGroups(12, 3); // Too many groups, too few tools per group
-      groups[0].id = groups[1].id; // Duplicate ID
+      const groups = createMockGroups(12, 3); // Tool/group count constraints don't cause errors (advisory)
+      groups[0].id = groups[1].id; // Duplicate ID (this should still fail)
       const constraints: GroupingConstraints = {
         minToolsPerGroup: 5,
         maxToolsPerGroup: 20,
@@ -426,8 +463,14 @@ describe("Grouping Validator", () => {
       const result = validateGroups(groups, constraints);
 
       // Assert
-      assertEquals(result.valid, false, "Should fail validation");
-      assert(result.errors.length >= 3, "Should accumulate all errors");
+      // Should fail only due to duplicate IDs (metadata validation)
+      // Not due to tool/group count constraints (advisory)
+      assertEquals(result.valid, false, "Should fail validation for metadata errors");
+      assert(result.errors.length >= 1, "Should have at least one error for duplicate IDs");
+      assert(
+        result.errors.some((e) => e.includes("unique") && e.includes("ID")),
+        "Error should mention non-unique IDs",
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- Relaxed validation to treat tool count and group count constraints as advisory guidelines
- Constraints (`minToolsPerGroup`, `maxToolsPerGroup`, `minGroups`, `maxGroups`) are no longer enforced during validation
- All metadata validations (unique IDs/names, non-empty fields) remain enforced

## Changes
### Validator (`src/grouping/validator.ts`)
- Commented out constraint enforcement for tool count per group
- Commented out constraint enforcement for group count
- Added documentation explaining constraints are advisory only
- Metadata validations remain unchanged

### Tests (`tests/unit/grouping/validator_test.ts`)
- Updated tests to verify constraints don't cause validation failures
- Changed test expectations from "should fail" to "should pass" for constraint violations
- Added "(advisory only)" annotations to clarify new behavior

## Rationale
Tool and group count constraints should serve as flexible guidelines for the LLM during grouping rather than hard requirements. This allows for more adaptive tool grouping based on the actual tool catalog characteristics while maintaining essential metadata integrity checks.

## Test Results
- All unit tests passing (including updated validator tests)
- All integration tests passing
- All distribution tests passing
- Lint and type checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)